### PR TITLE
Remove sphinx_js

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,8 +40,7 @@ release = ''
 # ones.
 extensions = [
     'sphinx.ext.autodoc', 
-    'sphinx.ext.napoleon', 
-    'sphinx_js']
+    'sphinx.ext.napoleon']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -159,4 +158,3 @@ texinfo_documents = [
 
 # -- Extension configuration -------------------------------------------------
 
-js_source_path = '..../frontend/src'


### PR DESCRIPTION
We discovered that including sphinx_js in the conf.py file will cause ReadtheDocs not to be able to run Sphinx and update itself.  Therefore, sphinx_js will have to be run on its own fork and added to ReadtheDocs manually.  I removed all references to sphinx_js in conf.py.  This should make ReadtheDocs operational again.