### PR TITLE
API authorization and tests for /user/<id> and /userlist/<ids>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ __pycache__/
 /.vs/whitman-books-online/v15/.suo
 /.vs/slnx.sqlite
 /.vs/ProjectSettings.json
+
+# Back end dev sqlite
+backend/api/data.db

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -110,10 +110,10 @@ def email_mismatch_headers(email, headers):
 
     Args:
         email (str): email address that has authorization
-        headers (dict of str): output from ``user_unauthorization()``
+        headers (dict of str): dictionary of HTTP headers in request
 
     Returns:
-        (dict, int): A tuple to be returned by Flask when token is unauthorized
+        (dict, int): A tuple to be returned by Flask when header is unauthorized
         bool: False when authorized
     """
     decoded_token = decoded_and_verified_token_from_headers(headers)
@@ -123,5 +123,32 @@ def email_mismatch_headers(email, headers):
             "message": "No valid token provided (possibly expired or not provided)"}, 401
     elif email != decoded_token["email"]:
         return {"message": email + " is not authorized"}, 403
+    else:
+        return False
+
+
+def google_tok_mismatch_headers(google_tok, headers):
+    """Process HTTP header for validated token and compare with Google ID
+
+    401 error if token is missing or invalid, 403 if the token's ID doesn't
+    match the given ID. False if they match.
+
+    Args:
+        google_tok (str): Google ID that has authorization
+        headers (dict of str): dictionary of HTTP headers in request
+
+    Returns:
+        (dict, int): A tuple to be returned by Flask when header is unauthorized
+        bool: False when authorized
+    """
+    decoded_token = decoded_and_verified_token_from_headers(headers)
+
+    if not decoded_token:
+        return {
+            "message": "No valid token provided (possibly expired or not provided)"}, 401
+    # It looks like the "sub" key in the JWT is what corresponds to the Google
+    # ID, but we'll see if this holds true...
+    elif google_tok != decoded_token["sub"]:
+        return {"message":  str(google_tok) + " is not authorized"}, 403
     else:
         return False

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -1,55 +1,45 @@
 from google.oauth2 import id_token
 from google.auth.transport import requests
 
-def get_user_email(user_token):
-    """Determine the email of the given Google Oauth2 token
+client_ids = (
+    "317596678792-2ekdkdrdlgsqdaudaag7t7m7qf4m0b17.apps.googleusercontent.com")
+authorized_email_domains = ("whitman.edu")
 
-    Gets the email address from Google and also verifies the token. Exception
-    is raised if an email isn't found for whatever reason or if token
-    verification fails.
+
+def verify_encoded_token(encoded_token):
+    """Verify and get the client's token
+
+    Verifies the token's signature, expiration, that it is from the API created
+    by the front end, that the email domain is one from
+    ``authorized_email_domains`` (whitman.edu), and that Google issued it.
 
     Args:
-        user_token (str): The client token to verify and get email from
+        encoded_token (str): The client token to verify and get email from
 
     Returns:
-        str: Email address
-
-    Raises:
-        ValueError: No valid email found
-
+        dict: validated token
+        NoneType: if token is invalid for whatever reason
     """
+    # Modified from
+    # https://developers.google.com/identity/sign-in/web/backend-auth
     try:
-        decoded_token = verify_user_token(user_token)
+        # Client ID of the Google API (found in Developer Console)
+
+        # Raises ValueError if token is invalid
+        decoded_token = id_token.verify_oauth2_token(
+            encoded_token, requests.Request())
+
+        if decoded_token["aud"] not in [client_ids]:
+            raise ValueError("Could not verify audience (API client ID)")
+
+        if decoded_token["hd"] not in authorized_email_domains:
+            raise ValueError("Domain of token not authorized")
+
+        if decoded_token["iss"] not in [
+                "accounts.google.com", "https://accounts.google.com"]:
+            raise ValueError("Token not issued by Google")
+
     except ValueError:
-        raise ValueError('No valid email found')
-
-    email = decoded_token['email']
-
-    return email
-
-def verify_user_token(user_token):
-    """Verify that the user's token is legit
-
-    Verifies the JWT signature, the aud claim, and the exp claim
-
-    Args:
-        user_token (str): The client token to verify and get email from
-
-    Returns:
-        Decoded JWT
-
-    Raises:
-        ValueError: Token is invalid
-    """
-    # Modified from https://developers.google.com/identity/sign-in/web/backend-auth
-
-    # Client ID of the Google API
-    CLIENT_ID = 'whitman-books'
-
-    # Raises ValueError if token is invalid
-    decoded_token = id_token.verify_oauth2_token(token, requests.Request(), CLIENT_ID)
-    # Raises ValueError if token isn't from Google
-    if idinfo['iss'] not in ['accounts.google.com', 'https://accounts.google.com']:
-        raise ValueError('Wrong issuer.')
+        return None
 
     return decoded_token

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -43,3 +43,59 @@ def decoded_and_verified_token(encoded_token):
         return None
 
     return decoded_token
+
+
+def unauthorized_headers(headers):
+    """Return Flask return tuple if request is unauthorized
+
+    Example:
+        Intended to be used in a conditional within a Flask HTTP method to see
+        if the user is authorized:
+
+        .. code-block:: python
+
+           auth_error = unauthorized_headers(flask.request.headers)
+           if auth_error:
+               return auth_error
+    """
+    decoded_token = decoded_and_verified_token_from_headers(headers)
+    if not decoded_token:
+        return {"message": "No valid token provided (possibly expired or not provided)"}, 401
+    else:
+        return False
+
+
+def decoded_and_verified_token_from_headers(headers):
+    """Get decoded token from HTTP headers
+
+    Get encoded token from headers and use ``verify_encoded_token()`` to
+    verify token before returning the decoded token.
+
+    Args:
+        headers (dict of str): headers from ``flask.request.headers``
+
+    Returns:
+        dict: validated token
+        NoneType: if token is invalid for whatever reason
+    """
+    encoded_token = get_encoded_token_from_headers(headers)
+    decoded_token = decoded_and_verified_token(encoded_token)
+    return decoded_token
+
+
+def get_encoded_token_from_headers(headers):
+    """Read encoded bearer token from HTTP header
+
+    Args:
+        flask.request.headers
+
+    Returns:
+        str: encoded token (JWT)
+        NoneType: when no Authorization header present
+    """
+    try:
+        auth_header = headers['Authorization']
+        encoded_token = auth_header.split(" ")[1]
+    except KeyError:
+        encoded_token = None
+    return encoded_token

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -6,12 +6,12 @@ client_ids = (
 authorized_email_domains = ("whitman.edu")
 
 
-def verify_encoded_token(encoded_token):
+def decoded_and_verified_token(encoded_token):
     """Verify and get the client's token
 
     Verifies the token's signature, expiration, that it is from the API created
-    by the front end, that the email domain is one from
-    ``authorized_email_domains`` (whitman.edu), and that Google issued it.
+    by the front end, **that the email domain is one from
+    ``authorized_email_domains`` (whitman.edu)**, and that Google issued it.
 
     Args:
         encoded_token (str): The client token to verify and get email from

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -1,0 +1,55 @@
+from google.oauth2 import id_token
+from google.auth.transport import requests
+
+def get_user_email(user_token):
+    """Determine the email of the given Google Oauth2 token
+
+    Gets the email address from Google and also verifies the token. Exception
+    is raised if an email isn't found for whatever reason or if token
+    verification fails.
+
+    Args:
+        user_token (str): The client token to verify and get email from
+
+    Returns:
+        str: Email address
+
+    Raises:
+        ValueError: No valid email found
+
+    """
+    try:
+        decoded_token = verify_user_token(user_token)
+    except ValueError:
+        raise ValueError('No valid email found')
+
+    email = decoded_token['email']
+
+    return email
+
+def verify_user_token(user_token):
+    """Verify that the user's token is legit
+
+    Verifies the JWT signature, the aud claim, and the exp claim
+
+    Args:
+        user_token (str): The client token to verify and get email from
+
+    Returns:
+        Decoded JWT
+
+    Raises:
+        ValueError: Token is invalid
+    """
+    # Modified from https://developers.google.com/identity/sign-in/web/backend-auth
+
+    # Client ID of the Google API
+    CLIENT_ID = 'whitman-books'
+
+    # Raises ValueError if token is invalid
+    decoded_token = id_token.verify_oauth2_token(token, requests.Request(), CLIENT_ID)
+    # Raises ValueError if token isn't from Google
+    if idinfo['iss'] not in ['accounts.google.com', 'https://accounts.google.com']:
+        raise ValueError('Wrong issuer.')
+
+    return decoded_token

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -60,7 +60,8 @@ def unauthorized_headers(headers):
     """
     decoded_token = decoded_and_verified_token_from_headers(headers)
     if not decoded_token:
-        return {"message": "No valid token provided (possibly expired or not provided)"}, 401
+        return {
+            "message": "No valid token provided (possibly expired or not provided)"}, 401
     else:
         return False
 
@@ -94,8 +95,33 @@ def get_encoded_token_from_headers(headers):
         NoneType: when no Authorization header present
     """
     try:
-        auth_header = headers['Authorization']
+        auth_header = headers["Authorization"]
         encoded_token = auth_header.split(" ")[1]
     except KeyError:
         encoded_token = None
     return encoded_token
+
+
+def email_mismatch_headers(email, headers):
+    """Process HTTP header for validated token and compare with email
+
+    401 error if token is missing or invalid, 403 if the token's email doesn't
+    match the given email. False if they match.
+
+    Args:
+        email (str): email address that has authorization
+        headers (dict of str): output from ``user_unauthorization()``
+
+    Returns:
+        (dict, int): A tuple to be returned by Flask when token is unauthorized
+        bool: False when authorized
+    """
+    decoded_token = decoded_and_verified_token_from_headers(headers)
+
+    if not decoded_token:
+        return {
+            "message": "No valid token provided (possibly expired or not provided)"}, 401
+    elif email != decoded_token["email"]:
+        return {"message": email + " is not authorized"}, 403
+    else:
+        return False

--- a/backend/api/book.py
+++ b/backend/api/book.py
@@ -238,71 +238,71 @@ class Book(Resource):
             return {"books": [book.bare_json() for book in data]}
         return {"message": "Book not found"}, 404
 
-        def post(self, isbns):
-            """Posts a book to the database.
+    def post(self, isbns):
+        """Posts a book to the database.
 
-            Args:
-                    isbns (str): The isbn of the book being posted.
+        Args:
+                isbns (str): The isbn of the book being posted.
 
-            Returns:
-                    message: What happened with the post call.
-            """
-            data = Book.parser.parse_args()
-            isbn = int(isbns) # string of only one ISBN
-            #Error handling, in case not all passed in
-            title = "None"
-            authors = "None"
-            categories = "None"
-            imagelinks = "None"
-            thumbnail = "None"
-            smallThumbnail = "None"
-            subtitle = "None"
-            publishedDate = "None"
-            previewLink = "None"
-            infoLink = "None"
-            canonicalVolumeLink = "None"
-            if BookModel.find_by_isbn(isbn):
-                return {'message': 'A book with isbn ' + str(isbn) + ' already exists'}, 400
-            if data["title"]:
-                title = data["title"]
-            if data["authors"]:
-                authors = ', '.join(author for author in data["authors"])
-            if data["subtitle"]:
-                subtitle = data["subtitle"]
-            if data["publishedDate"]:
-                publishedDate = data["publishedDate"]
-            if data["previewLink"]:
-                previewLink = data["previewLink"]
-            if data["infoLink"]:
-                infoLink = data["infoLink"]
-            if data["canonicalVolumeLink"]:
-                canonicalVolumeLink = data["canonicalVolumeLink"]
-            if data["categories"]:
-                categories = ', '.join(category for category in data["categories"])
-            if data["imageLinks"]:
-                imagelinks = ast.literal_eval(data["imageLinks"][0]) #dumb json parsing
-                if imagelinks["thumbnail"]:
-                    thumbnail = imagelinks["thumbnail"] # dumb json parsing.
-                if imagelinks["smallThumbnail"]:
-                    smallThumbnail = imagelinks["smallThumbnail"] # dumb json parsing
-            book = BookModel(title, subtitle, authors, isbn, categories, publishedDate, smallThumbnail, thumbnail, previewLink, infoLink, canonicalVolumeLink)
-            book.save_to_db()
-            return {"message": "Book created successfully."}, 201
+        Returns:
+                message: What happened with the post call.
+        """
+        data = Book.parser.parse_args()
+        isbn = int(isbns) # string of only one ISBN
+        #Error handling, in case not all passed in
+        title = "None"
+        authors = "None"
+        categories = "None"
+        imagelinks = "None"
+        thumbnail = "None"
+        smallThumbnail = "None"
+        subtitle = "None"
+        publishedDate = "None"
+        previewLink = "None"
+        infoLink = "None"
+        canonicalVolumeLink = "None"
+        if BookModel.find_by_isbn(isbn):
+            return {'message': 'A book with isbn ' + str(isbn) + ' already exists'}, 400
+        if data["title"]:
+            title = data["title"]
+        if data["authors"]:
+            authors = ', '.join(author for author in data["authors"])
+        if data["subtitle"]:
+            subtitle = data["subtitle"]
+        if data["publishedDate"]:
+            publishedDate = data["publishedDate"]
+        if data["previewLink"]:
+            previewLink = data["previewLink"]
+        if data["infoLink"]:
+            infoLink = data["infoLink"]
+        if data["canonicalVolumeLink"]:
+            canonicalVolumeLink = data["canonicalVolumeLink"]
+        if data["categories"]:
+            categories = ', '.join(category for category in data["categories"])
+        if data["imageLinks"]:
+            imagelinks = ast.literal_eval(data["imageLinks"][0]) #dumb json parsing
+            if imagelinks["thumbnail"]:
+                thumbnail = imagelinks["thumbnail"] # dumb json parsing.
+            if imagelinks["smallThumbnail"]:
+                smallThumbnail = imagelinks["smallThumbnail"] # dumb json parsing
+        book = BookModel(title, subtitle, authors, isbn, categories, publishedDate, smallThumbnail, thumbnail, previewLink, infoLink, canonicalVolumeLink)
+        book.save_to_db()
+        return {"message": "Book created successfully."}, 201
 
-        def delete(self, isbns):
-            """Deletes a book from the database.
+    def delete(self, isbns):
+        """Deletes a book from the database.
 
-            Args:
-                    isbns (str): The isbn of the book being deleted.
+        Args:
+                isbns (str): The isbn of the book being deleted.
 
-            Returns:
-                    message: What happened with the delete call.
-            """
-            book = BookModel.find_by_isbn(isbns)
-            if book:
-                book.delete_from_db()
-                return {"message": "Book deleted"}
-            return {"message": "Book with isbn (" + isbns + ") does not exist."}
+        Returns:
+                message: What happened with the delete call.
+        """
+        book = BookModel.find_by_isbn(isbns)
+        if book:
+            book.delete_from_db()
+            return {"message": "Book deleted"}
+        return {"message": "Book with isbn (" + isbns + ") does not exist."}
 
 class BookList(Resource):
     """The BookList object handles the entire list of books in the database.

--- a/backend/api/user.py
+++ b/backend/api/user.py
@@ -238,6 +238,8 @@ class User(Resource):
         Returns:
                 message: What happened with the delete call.
         """
+        auth_error = auth.google_tok_mismatch_headers(google_tok, request.headers)
+        if auth_error: return auth_error
         user = UserModel.find_by_google_tok(google_tok)
         if user:
             user.delete_from_db()

--- a/backend/api/user.py
+++ b/backend/api/user.py
@@ -264,7 +264,8 @@ Attributes:
         Returns:
                 json[]: A list of jsonified users that match the tokens.
         """
-
+        auth_error = auth.google_tok_mismatch_headers(google_tok, request.headers)
+        if auth_error: return auth_error
         tokens = tokens.split(",")
         all_users = UserModel.query.filter(
             UserModel.google_tok.in_(tokens)).all()

--- a/backend/api/user.py
+++ b/backend/api/user.py
@@ -223,7 +223,7 @@ class User(Resource):
         data = User.parser.parse_args()
         print("hello")
         if UserModel.find_by_google_tok(google_tok):
-            return {'message': 'A user with that google_token already exists'}, 400
+            return {'message': 'user '+str(google_tok)+' already exists'}, 200
         user = UserModel(google_tok, data['imageURL'], data['email'],
                          data['name'], data['givenName'], data['familyName'])
         user.save_to_db()
@@ -242,7 +242,7 @@ class User(Resource):
         if user:
             user.delete_from_db()
             return {"message": "User deleted"}
-        return {"message": "User with user_id (" + google_tok + ") does not exist."}
+        return {"message": "User with user_id (" + google_tok + ") does not exist."}, 404
 
 
 class UserList(Resource):

--- a/backend/api/user.py
+++ b/backend/api/user.py
@@ -2,8 +2,10 @@ from sqlalchemy import Table, Column, Integer, ForeignKey
 from sqlalchemy.orm import relationship
 from flask_restful import Resource, reqparse
 from math import ceil
+from flask import request
 
 from db import db
+import auth
 
 page_size = 20
 
@@ -197,7 +199,8 @@ class User(Resource):
         Returns:
                 json[]: A list of jsonified users.
         """
-
+        auth_error = auth.unauthorized_headers(request.headers)
+        if auth_error: return auth_error
         user = UserModel.find_by_google_tok(google_tok)
         listing_IDs = []
         if user:

--- a/backend/api/user.py
+++ b/backend/api/user.py
@@ -218,6 +218,8 @@ class User(Resource):
         Returns:
                 message: What happened with the post call.
         """
+        auth_error = auth.google_tok_mismatch_headers(google_tok, request.headers)
+        if auth_error: return auth_error
         data = User.parser.parse_args()
         print("hello")
         if UserModel.find_by_google_tok(google_tok):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ flask_jwt
 flask_sqlalchemy
 flask_cors
 google-auth
+requirements

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,4 +3,4 @@ flask_jwt
 flask_sqlalchemy
 flask_cors
 google-auth
-requirements
+requests

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ flask_restful
 flask_jwt
 flask_sqlalchemy
 flask_cors
+google-auth

--- a/backend/tests/test_all.py
+++ b/backend/tests/test_all.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+import os
+import unittest
+
+def suite():
+    loader = unittest.TestLoader()
+    start_dir = os.getcwd()
+    suite = loader.discover(start_dir)
+    return suite
+
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(suite())

--- a/backend/tests/test_api_base.py
+++ b/backend/tests/test_api_base.py
@@ -5,7 +5,7 @@ import unittest
 from api import auth
 
 
-class TestWithCredentials(unittest.TestCase):
+class ApiTestBase(unittest.TestCase):
     def setUp(self):
         try:
             self.valid_jwt = os.environ['VALID_JWT']

--- a/backend/tests/test_api_user.py
+++ b/backend/tests/test_api_user.py
@@ -79,6 +79,38 @@ class UserTestCase(TestWithCredentials):
         self.assertEqual(empty_header.status_code, 401)
         self.assertEqual(nonexistent_user.status_code, 404)
 
+    def user_exists(self):
+        """Helper function to ensure self.valid_google_tok has a user entry
+        """
+        user_exists = requests.post(
+            self.user_endpoint,
+            headers=self.valid_auth_header,
+            params=self.user_data)
+        self.assertIn(user_exists.status_code, [200, 201])
+
+    def test_user_delete(self):
+        self.user_exists()
+        authorized_header = requests.delete(
+            self.user_endpoint, headers=self.valid_auth_header)
+        self.user_exists()
+        unauthorized_header = requests.delete(
+            self.user_endpoint, headers=self.invalid_auth_header)
+        self.user_exists()
+        empty_header = requests.delete(
+            self.user_endpoint,
+            headers=self.invalid_auth_header)
+        self.user_exists()
+        nonexistent_user = requests.delete(
+            self.nonexistent_endpoint,
+            headers=self.valid_auth_header)
+        self.user_exists()
+        self.assertEqual(authorized_header.status_code, 200)
+        self.assertEqual(unauthorized_header.status_code, 401)
+        self.assertEqual(empty_header.status_code, 401)
+        # Even though a 404 would make sense, the user is more fundamentally
+        # trying to perform an unathorized action
+        self.assertEqual(nonexistent_user.status_code, 403)
+
 
 # # Inherits from TestWithCredentials to avoid rewriting SetUp()
 # class UserListTestCase(TestWithCredentials):

--- a/backend/tests/test_api_user.py
+++ b/backend/tests/test_api_user.py
@@ -10,12 +10,20 @@ class UserTestCase(TestWithCredentials):
         self.api_base = 'http://localhost:5000/'
         self.user_endpoint = self.api_base + \
             'user/' + str(self.valid_google_tok)
+        self.user_data = {
+            "imageURL": self.valid_token["picture"],
+            "email": self.valid_token["email"],
+            "name": self.valid_token["name"],
+            "givenName": self.valid_token["given_name"],
+            "familyName": self.valid_token["family_name"],
+        }
 
     # Assumes user does exist
     def test_user_get(self):
         user_exists = requests.post(
             self.user_endpoint,
-            headers=self.valid_auth_header)
+            headers=self.valid_auth_header,
+            params=self.user_data)
         # Ensure already existed or does now exist
         self.assertIn(user_exists.status_code, [201, 400])
         nonexistent_endpoint = self.api_base + \

--- a/backend/tests/test_api_user.py
+++ b/backend/tests/test_api_user.py
@@ -1,10 +1,10 @@
-from test_with_credentials import TestWithCredentials
+from test_api_base import ApiTestBase
 from api import auth
 import requests
 
 
-# Inherits from TestWithCredentials to avoid rewriting SetUp()
-class UserTestCase(TestWithCredentials):
+# Inherits from ApiTestBase to avoid rewriting SetUp()
+class UserTestCase(ApiTestBase):
     def setUp(self):
         super(UserTestCase, self).setUp()
         # Some testing logic is based on this endpoint being for the valid user
@@ -111,8 +111,8 @@ class UserTestCase(TestWithCredentials):
         self.assertEqual(nonexistent_user.status_code, 403)
 
 
-# Inherits from TestWithCredentials to avoid rewriting SetUp()
-class UserListTestCase(TestWithCredentials):
+# Inherits from ApiTestBase to avoid rewriting SetUp()
+class UserListTestCase(ApiTestBase):
     def setUp(self):
         super(UserListTestCase, self).setUp()
         # Some testing logic is based on this endpoint being for the valid user

--- a/backend/tests/test_api_user.py
+++ b/backend/tests/test_api_user.py
@@ -7,7 +7,6 @@ import requests
 class UserTestCase(TestWithCredentials):
     def setUp(self):
         super(UserTestCase, self).setUp()
-        self.api_base = 'http://localhost:5000/'
         # Some testing logic is based on this endpoint being for the valid user
         # Expect some breakage if you change it
         self.user_endpoint = self.api_base + \
@@ -112,9 +111,52 @@ class UserTestCase(TestWithCredentials):
         self.assertEqual(nonexistent_user.status_code, 403)
 
 
-# # Inherits from TestWithCredentials to avoid rewriting SetUp()
-# class UserListTestCase(TestWithCredentials):
-#     pass
+# Inherits from TestWithCredentials to avoid rewriting SetUp()
+class UserListTestCase(TestWithCredentials):
+    def setUp(self):
+        super(UserListTestCase, self).setUp()
+        # Some testing logic is based on this endpoint being for the valid user
+        # Expect some breakage if you change it
+        self.endpoint = self.api_base + \
+            'user/' + str(self.valid_google_tok)
+        self.user_data = {
+            "imageURL": self.valid_token["picture"],
+            "email": self.valid_token["email"],
+            "name": self.valid_token["name"],
+            "givenName": self.valid_token["given_name"],
+            "familyName": self.valid_token["family_name"],
+        }
+        self.nonexistent_endpoint = self.api_base + \
+            'user/' + str(self.invalid_google_tok)
+
+    def user_exists(self):
+        """Helper function to ensure self.valid_google_tok has a user entry
+        """
+        user_exists = requests.post(
+            self.endpoint,
+            headers=self.valid_auth_header,
+            params=self.user_data)
+        self.assertIn(user_exists.status_code, [200, 201])
+
+    def test_userlist_get(self):
+        # Only gets a list of one user, since the authorization requirements
+        # for user creation make testing a little bit harder
+        self.user_exists()
+        authorized_header = requests.get(
+            self.endpoint, headers=self.valid_auth_header)
+        unauthorized_header = requests.get(
+            self.endpoint, headers=self.invalid_auth_header)
+        empty_header = requests.get(
+            self.endpoint,
+            headers=self.invalid_auth_header)
+        nonexistent_user = requests.get(
+            self.nonexistent_endpoint,
+            headers=self.valid_auth_header)
+        self.assertEqual(authorized_header.status_code, 200)
+        self.assertEqual(unauthorized_header.status_code, 401)
+        self.assertEqual(empty_header.status_code, 401)
+        self.assertEqual(nonexistent_user.status_code, 404)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/backend/tests/test_api_user.py
+++ b/backend/tests/test_api_user.py
@@ -1,0 +1,44 @@
+from test_with_credentials import TestWithCredentials
+from api import auth
+import requests
+
+
+# Inherits from TestWithCredentials to avoid rewriting SetUp()
+class UserTestCase(TestWithCredentials):
+    def setUp(self):
+        super(UserTestCase, self).setUp()
+        self.api_base = 'http://localhost:5000/'
+        self.user_endpoint = self.api_base + \
+            'user/' + str(self.valid_google_tok)
+
+    # Assumes user does exist
+    def test_user_get(self):
+        user_exists = requests.post(
+            self.user_endpoint,
+            headers=self.valid_auth_header)
+        # Ensure already existed or does now exist
+        self.assertIn(user_exists.status_code, [201, 400])
+        nonexistent_endpoint = self.api_base + \
+            'user/' + str(self.invalid_google_tok)
+        authorized_header = requests.get(
+            self.user_endpoint, headers=self.valid_auth_header)
+        unauthorized_header = requests.get(
+            self.user_endpoint, headers=self.invalid_auth_header)
+        empty_header = requests.get(
+            self.user_endpoint,
+            headers=self.invalid_auth_header)
+        nonexistent_user = requests.get(
+            nonexistent_endpoint,
+            headers=self.valid_auth_header)
+        self.assertEqual(authorized_header.status_code, 200)
+        self.assertEqual(unauthorized_header.status_code, 401)
+        self.assertEqual(empty_header.status_code, 401)
+        self.assertEqual(nonexistent_user.status_code, 404)
+
+
+# # Inherits from TestWithCredentials to avoid rewriting SetUp()
+# class UserListTestCase(TestWithCredentials):
+#     pass
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import unittest
+import warnings
+
+from api import auth
+
+# Define decorator to supress an eroneous warning
+# https://stackoverflow.com/a/26620811
+def ignore_warnings(test_func):
+    def do_test(self, *args, **kwargs):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", ResourceWarning)
+            test_func(self, *args, **kwargs)
+    return do_test
+
+class UserTestCase(unittest.TestCase):
+    def setUp(self):
+        try:
+            self.jwt = os.environ['JWT']
+        except KeyError:
+            sys.exit(1)
+
+    @ignore_warnings
+    def test_decoded_and_verified_token(self):
+        token = auth.decoded_and_verified_token(self.jwt)
+        self.assertIsNotNone(token)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -39,6 +39,23 @@ class UserTestCase(TestWithCredentials):
         self.assertEqual(invalid_header[1], 401)
         self.assertEqual(empty_header[1], 401)
 
+    def test_google_tok_mismatch_headers(self):
+        valid_tok_valid_header = auth.google_tok_mismatch_headers(
+            self.valid_google_tok, self.valid_auth_header)
+        invalid_tok_valid_header = auth.google_tok_mismatch_headers(
+            self.invalid_google_tok, self.valid_auth_header)
+        invalid_header = auth.google_tok_mismatch_headers(
+                self.valid_google_tok, self.invalid_auth_header)
+        empty_header = auth.google_tok_mismatch_headers(
+                self.valid_google_tok, self.empty_auth_header)
+        # Valid header and matching Google token should return false
+        self.assertFalse(valid_tok_valid_header)
+        # Valid header but Google token mismatch should return a 403 error
+        self.assertEqual(invalid_tok_valid_header[1], 403)
+        # Invalid and empty headers should return a 401 error message
+        self.assertEqual(invalid_header[1], 401)
+        self.assertEqual(empty_header[1], 401)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -7,6 +7,8 @@ from api import auth
 
 # Define decorator to supress an eroneous warning
 # https://stackoverflow.com/a/26620811
+
+
 def ignore_warnings(test_func):
     def do_test(self, *args, **kwargs):
         with warnings.catch_warnings():
@@ -14,17 +16,62 @@ def ignore_warnings(test_func):
             test_func(self, *args, **kwargs)
     return do_test
 
+
 class UserTestCase(unittest.TestCase):
     def setUp(self):
         try:
-            self.jwt = os.environ['JWT']
+            self.valid_jwt = os.environ['JWT']
+            # Assumes decoded_and_verified_token() works
+            self.assertIsNotNone(
+                auth.decoded_and_verified_token(
+                    self.valid_jwt))
         except KeyError:
             sys.exit(1)
+        self.invalid_jwt = (
+            'eyJhbGciOiJSUzI1NiIsImtpZCI6ImFmZmM2MjkwN2E0NDYxODJhZGMxZmE0ZT'
+            'gxZmRiYTYzMTBkY2U2M2YifQ.eyJhenAiOiIzMTc1OTY2Nzg3OTItMmVrZGtkc'
+            'mRsZ3NxZGF1ZGFhZzd0N203cWY0bTBiMTcuYXBwcy5nb29nbGV1c2VyY29udGV'
+            'udC5jb20iLCJhdWQiOiIzMTc1OTY2Nzg3OTItMmVrZGtkcmRsZ3NxZGF1ZGFhZ'
+            'zd0N203cWY0bTBiMTcuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWI'
+            'iOiIxMTY2MDU2ODQwMDgyNjkwNjExMjgiLCJoZCI6IndoaXRtYW4uZWR1IiwiZ'
+            'W1haWwiOiJmYXJtYW5ybEB3aGl0bWFuLmVkdSIsImVtYWlsX3ZlcmlmaWVkIjp'
+            '0cnVlLCJhdF9oYXNoIjoicDNZamFYamZ3RWZEN1JiSlhJNnR3QSIsImV4cCI6M'
+            'TUyNDY4Mzc2MiwiaXNzIjoiYWNjb3VudHMuZ29vZ2xlLmNvbSIsImp0aSI6IjR'
+            'lN2UwZGI0OThkYTIzMTU5ZDhlN2FmYWE4NzExNGI3MDFkZGU5NmEiLCJpYXQiO'
+            'jE1MjQ2ODAxNjIsIm5hbWUiOiJSaWNoYXJkIEZhcm1hbiIsInBpY3R1cmUiOiJ'
+            'odHRwczovL2xoNC5nb29nbGV1c2VyY29udGVudC5jb20vLTdWUDcySDlxZVJJL'
+            '0FBQUFBQUFBQUFJL0FBQUFBQUFBQXM0L1VrdEtBMWdnTnV3L3M5Ni1jL3Bob3R'
+            'vLmpwZyIsImdpdmVuX25hbWUiOiJSaWNoYXJkIiwiZmFtaWx5X25hbWUiOiJGY'
+            'XJtYW4iLCJsb2NhbGUiOiJlbiJ9.TDxHNjSV5o5NZJzaQnulFj_sYu-8QdmPBE'
+            'TTh032P-cxh3M2XJHgJ96oiRldHeQ8J30WmwGz21e9zYdyE4S2HiSX1JAoFi2J'
+            'QpWIHEbdVM5cddypoPKN4yTBiqHbsyS-S5IwVqUHXb2O9_ARBmu1WIaKijQ5i-'
+            'fxy5cQzz8ih1X9Kf2LouYA17hdMkHXTqQ5iL01obrBN-GsSL-FlePFYx5CXk7Y'
+            'UrMlgoEym6ly4gWaoiLoXi8ubSu1OTllTGCrk4HC-chlyLQ2EToeWAFfUCNSWl'
+            'jFYRwm81RSIeFV5oQEClycnWPfIhXMXaCoGdxqrTdzd1pfe1GQaxCuHhAnCw'
+        )
+        self.valid_auth_header = {'Authorization': 'Bearer ' + self.valid_jwt}
+        self.invalid_auth_header = {
+            'Authorization': 'Bearer ' + self.invalid_jwt}
+        self.empty_auth_header = {}
 
-    @ignore_warnings
-    def test_decoded_and_verified_token(self):
-        token = auth.decoded_and_verified_token(self.jwt)
-        self.assertIsNotNone(token)
+    def test_get_encoded_token_from_headers(self):
+        encoded_token = auth.get_encoded_token_from_headers(
+            self.valid_auth_header)
+        no_token = auth.get_encoded_token_from_headers(self.empty_auth_header)
+        self.assertIsNotNone(encoded_token)
+        self.assertIsNone(no_token)
+
+    def test_decoded_and_verified_token_from_headers(self):
+        valid_token = auth.decoded_and_verified_token_from_headers(
+            self.valid_auth_header)
+        invalid_token = auth.decoded_and_verified_token_from_headers(
+            self.invalid_auth_header)
+        empty_token = auth.decoded_and_verified_token_from_headers(
+            self.empty_auth_header)
+        self.assertIsInstance(valid_token, dict)
+        self.assertIsNone(invalid_token)
+        self.assertIsNone(empty_token)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,9 +1,9 @@
-from test_with_credentials import TestWithCredentials
+from test_api_base import ApiTestBase
 from api import auth
 
 
-# Inherits from TestWithCredentials to avoid rewriting SetUp()
-class UserTestCase(TestWithCredentials):
+# Inherits from ApiTestBase to avoid rewriting SetUp()
+class UserTestCase(ApiTestBase):
     def test_get_encoded_token_from_headers(self):
         encoded_token = auth.get_encoded_token_from_headers(
             self.valid_auth_header)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,61 +1,9 @@
-import os
-import sys
-import unittest
-import warnings
-
+from test_with_credentials import TestWithCredentials
 from api import auth
 
-# Define decorator to supress an eroneous warning
-# https://stackoverflow.com/a/26620811
 
-
-def ignore_warnings(test_func):
-    def do_test(self, *args, **kwargs):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", ResourceWarning)
-            test_func(self, *args, **kwargs)
-    return do_test
-
-
-class UserTestCase(unittest.TestCase):
-    def setUp(self):
-        try:
-            self.valid_jwt = os.environ['VALID_JWT']
-            self.valid_email = os.environ['VALID_EMAIL']
-            # Assumes decoded_and_verified_token() works
-            self.assertIsNotNone(
-                auth.decoded_and_verified_token(
-                    self.valid_jwt))
-        except KeyError:
-            sys.exit(1)
-        self.alt_email = 'other_user@whitman.edu'
-        self.invalid_jwt = (
-            'eyJhbGciOiJSUzI1NiIsImtpZCI6ImFmZmM2MjkwN2E0NDYxODJhZGMxZmE0ZT'
-            'gxZmRiYTYzMTBkY2U2M2YifQ.eyJhenAiOiIzMTc1OTY2Nzg3OTItMmVrZGtkc'
-            'mRsZ3NxZGF1ZGFhZzd0N203cWY0bTBiMTcuYXBwcy5nb29nbGV1c2VyY29udGV'
-            'udC5jb20iLCJhdWQiOiIzMTc1OTY2Nzg3OTItMmVrZGtkcmRsZ3NxZGF1ZGFhZ'
-            'zd0N203cWY0bTBiMTcuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWI'
-            'iOiIxMTY2MDU2ODQwMDgyNjkwNjExMjgiLCJoZCI6IndoaXRtYW4uZWR1IiwiZ'
-            'W1haWwiOiJmYXJtYW5ybEB3aGl0bWFuLmVkdSIsImVtYWlsX3ZlcmlmaWVkIjp'
-            '0cnVlLCJhdF9oYXNoIjoicDNZamFYamZ3RWZEN1JiSlhJNnR3QSIsImV4cCI6M'
-            'TUyNDY4Mzc2MiwiaXNzIjoiYWNjb3VudHMuZ29vZ2xlLmNvbSIsImp0aSI6IjR'
-            'lN2UwZGI0OThkYTIzMTU5ZDhlN2FmYWE4NzExNGI3MDFkZGU5NmEiLCJpYXQiO'
-            'jE1MjQ2ODAxNjIsIm5hbWUiOiJSaWNoYXJkIEZhcm1hbiIsInBpY3R1cmUiOiJ'
-            'odHRwczovL2xoNC5nb29nbGV1c2VyY29udGVudC5jb20vLTdWUDcySDlxZVJJL'
-            '0FBQUFBQUFBQUFJL0FBQUFBQUFBQXM0L1VrdEtBMWdnTnV3L3M5Ni1jL3Bob3R'
-            'vLmpwZyIsImdpdmVuX25hbWUiOiJSaWNoYXJkIiwiZmFtaWx5X25hbWUiOiJGY'
-            'XJtYW4iLCJsb2NhbGUiOiJlbiJ9.TDxHNjSV5o5NZJzaQnulFj_sYu-8QdmPBE'
-            'TTh032P-cxh3M2XJHgJ96oiRldHeQ8J30WmwGz21e9zYdyE4S2HiSX1JAoFi2J'
-            'QpWIHEbdVM5cddypoPKN4yTBiqHbsyS-S5IwVqUHXb2O9_ARBmu1WIaKijQ5i-'
-            'fxy5cQzz8ih1X9Kf2LouYA17hdMkHXTqQ5iL01obrBN-GsSL-FlePFYx5CXk7Y'
-            'UrMlgoEym6ly4gWaoiLoXi8ubSu1OTllTGCrk4HC-chlyLQ2EToeWAFfUCNSWl'
-            'jFYRwm81RSIeFV5oQEClycnWPfIhXMXaCoGdxqrTdzd1pfe1GQaxCuHhAnCw'
-        )
-        self.valid_auth_header = {'Authorization': 'Bearer ' + self.valid_jwt}
-        self.invalid_auth_header = {
-            'Authorization': 'Bearer ' + self.invalid_jwt}
-        self.empty_auth_header = {}
-
+# Inherits from TestWithCredentials to avoid rewriting SetUp()
+class UserTestCase(TestWithCredentials):
     def test_get_encoded_token_from_headers(self):
         encoded_token = auth.get_encoded_token_from_headers(
             self.valid_auth_header)

--- a/backend/tests/test_with_credentials.py
+++ b/backend/tests/test_with_credentials.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import unittest
+
+from api import auth
+
+
+class TestWithCredentials(unittest.TestCase):
+    def setUp(self):
+        try:
+            self.valid_jwt = os.environ['VALID_JWT']
+            self.valid_email = os.environ['VALID_EMAIL']
+            # Assumes decoded_and_verified_token() works
+            self.assertIsNotNone(
+                auth.decoded_and_verified_token(
+                    self.valid_jwt))
+        except KeyError:
+            sys.exit(1)
+        self.alt_email = 'other_user@whitman.edu'
+        self.invalid_jwt = (
+            'eyJhbGciOiJSUzI1NiIsImtpZCI6ImFmZmM2MjkwN2E0NDYxODJhZGMxZmE0ZT'
+            'gxZmRiYTYzMTBkY2U2M2YifQ.eyJhenAiOiIzMTc1OTY2Nzg3OTItMmVrZGtkc'
+            'mRsZ3NxZGF1ZGFhZzd0N203cWY0bTBiMTcuYXBwcy5nb29nbGV1c2VyY29udGV'
+            'udC5jb20iLCJhdWQiOiIzMTc1OTY2Nzg3OTItMmVrZGtkcmRsZ3NxZGF1ZGFhZ'
+            'zd0N203cWY0bTBiMTcuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWI'
+            'iOiIxMTY2MDU2ODQwMDgyNjkwNjExMjgiLCJoZCI6IndoaXRtYW4uZWR1IiwiZ'
+            'W1haWwiOiJmYXJtYW5ybEB3aGl0bWFuLmVkdSIsImVtYWlsX3ZlcmlmaWVkIjp'
+            '0cnVlLCJhdF9oYXNoIjoicDNZamFYamZ3RWZEN1JiSlhJNnR3QSIsImV4cCI6M'
+            'TUyNDY4Mzc2MiwiaXNzIjoiYWNjb3VudHMuZ29vZ2xlLmNvbSIsImp0aSI6IjR'
+            'lN2UwZGI0OThkYTIzMTU5ZDhlN2FmYWE4NzExNGI3MDFkZGU5NmEiLCJpYXQiO'
+            'jE1MjQ2ODAxNjIsIm5hbWUiOiJSaWNoYXJkIEZhcm1hbiIsInBpY3R1cmUiOiJ'
+            'odHRwczovL2xoNC5nb29nbGV1c2VyY29udGVudC5jb20vLTdWUDcySDlxZVJJL'
+            '0FBQUFBQUFBQUFJL0FBQUFBQUFBQXM0L1VrdEtBMWdnTnV3L3M5Ni1jL3Bob3R'
+            'vLmpwZyIsImdpdmVuX25hbWUiOiJSaWNoYXJkIiwiZmFtaWx5X25hbWUiOiJGY'
+            'XJtYW4iLCJsb2NhbGUiOiJlbiJ9.TDxHNjSV5o5NZJzaQnulFj_sYu-8QdmPBE'
+            'TTh032P-cxh3M2XJHgJ96oiRldHeQ8J30WmwGz21e9zYdyE4S2HiSX1JAoFi2J'
+            'QpWIHEbdVM5cddypoPKN4yTBiqHbsyS-S5IwVqUHXb2O9_ARBmu1WIaKijQ5i-'
+            'fxy5cQzz8ih1X9Kf2LouYA17hdMkHXTqQ5iL01obrBN-GsSL-FlePFYx5CXk7Y'
+            'UrMlgoEym6ly4gWaoiLoXi8ubSu1OTllTGCrk4HC-chlyLQ2EToeWAFfUCNSWl'
+            'jFYRwm81RSIeFV5oQEClycnWPfIhXMXaCoGdxqrTdzd1pfe1GQaxCuHhAnCw'
+        )
+        self.valid_auth_header = {'Authorization': 'Bearer ' + self.valid_jwt}
+        self.invalid_auth_header = {
+            'Authorization': 'Bearer ' + self.invalid_jwt}
+        self.empty_auth_header = {}

--- a/backend/tests/test_with_credentials.py
+++ b/backend/tests/test_with_credentials.py
@@ -9,12 +9,12 @@ class TestWithCredentials(unittest.TestCase):
     def setUp(self):
         try:
             self.valid_jwt = os.environ['VALID_JWT']
-            self.valid_email = os.environ['VALID_EMAIL']
-            self.valid_google_tok = os.environ['VALID_GOOGLE_TOK']
             # Assumes decoded_and_verified_token() works
-            self.assertIsNotNone(
-                auth.decoded_and_verified_token(
-                    self.valid_jwt))
+            self.valid_token = auth.decoded_and_verified_token(self.valid_jwt)
+            self.assertIsNotNone(self.valid_token)
+            self.valid_email = self.valid_token['email']
+            self.valid_google_tok = self.valid_token['sub']
+        # Exit if above environment variables aren't set
         except KeyError:
             sys.exit(1)
         self.alt_email = 'other_user@whitman.edu'

--- a/backend/tests/test_with_credentials.py
+++ b/backend/tests/test_with_credentials.py
@@ -45,3 +45,4 @@ class TestWithCredentials(unittest.TestCase):
         self.invalid_auth_header = {
             'Authorization': 'Bearer ' + self.invalid_jwt}
         self.empty_auth_header = {}
+        self.api_base = 'http://localhost:5000/'

--- a/backend/tests/test_with_credentials.py
+++ b/backend/tests/test_with_credentials.py
@@ -10,6 +10,7 @@ class TestWithCredentials(unittest.TestCase):
         try:
             self.valid_jwt = os.environ['VALID_JWT']
             self.valid_email = os.environ['VALID_EMAIL']
+            self.valid_google_tok = os.environ['VALID_GOOGLE_TOK']
             # Assumes decoded_and_verified_token() works
             self.assertIsNotNone(
                 auth.decoded_and_verified_token(
@@ -39,6 +40,7 @@ class TestWithCredentials(unittest.TestCase):
             'UrMlgoEym6ly4gWaoiLoXi8ubSu1OTllTGCrk4HC-chlyLQ2EToeWAFfUCNSWl'
             'jFYRwm81RSIeFV5oQEClycnWPfIhXMXaCoGdxqrTdzd1pfe1GQaxCuHhAnCw'
         )
+        self.invalid_google_tok = 000000000000000000000
         self.valid_auth_header = {'Authorization': 'Bearer ' + self.valid_jwt}
         self.invalid_auth_header = {
             'Authorization': 'Bearer ' + self.invalid_jwt}

--- a/scripts/get_jwt.py
+++ b/scripts/get_jwt.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+import os
+import sys
+import json
+
+
+def decode_jwt_from_console():
+    """Get JWT from token issued by Google
+
+    Can be found as a response from Google when signing into front end app.
+    Prints JWT and puts it on the system clipboard, ready to be pasted.
+    """
+    import pyperclip
+    response = json.loads(sys.argv[1])
+    jwt_key = 'id_token'
+    jwt = response[jwt_key]
+    pyperclip.copy(jwt)
+    print(jwt)
+
+
+if __name__ == '__main__':
+    decode_jwt_from_console()

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,1 @@
+oauth2client


### PR DESCRIPTION
Pretty sizable PR here, but because it contains tests I'm not too leery about it. Most choices I made for authorization should be pretty straightforward I think. Two things worthy of note:
1. I broke API...a little. Just some changed status codes as of a69cfb4abc883d8d5af752a8fbca0af2ba6fe965. I'm imagining that front end folks shouldn't care too much, and that my decisions as noted in that commit are pretty reasonable IMO, but if anyone minds I can revert this without much fuss.
2. Testing is...not perfect. You need to provide a valid Google JWT as an environment variable in the terminal. In the terminal where you're going to run the tests, you'll need to enter `export VALID_JWT='<your jwt>'`. This will allow the tests to work properly. I wrote a script `scripts/get_jwt.py` to help extract the JWT from a response you get when logging into the front end, but get the JWT however you want.

Oh, the tests also assume an empty database. They will work fine on an already-used database, but I make no promises about the state of your data *after* the tests run.